### PR TITLE
Fix missing plugins module error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,9 +98,6 @@ node_modules/
 # maintenance locker
 maintenance_mode_state.txt
 
-# plugin dev directory
-InvenTree/plugins/
-
 # Compiled translation files
 *.mo
 


### PR DESCRIPTION
Kadangi InvenTree/plugins folderis skirtas custom įskiepiams, todėl jie buvo jį įtraukę į gitignore, kad pluginai nebūtų keliami iš vartotojų į pagrindinę repozitoriją. Išmečiau taisyklę iš .gitignore ir pridedu folderį, kad užskaitytų, kaip importuojamą python modulį.